### PR TITLE
Removed Sso prefix

### DIFF
--- a/Controller/TrustedSsoController.php
+++ b/Controller/TrustedSsoController.php
@@ -2,13 +2,13 @@
 
 namespace BeSimple\SsoAuthBundle\Controller;
 
-use BeSimple\SsoAuthBundle\Sso\SsoProviderInterface;
+use BeSimple\SsoAuthBundle\Sso\ProviderInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 
 class TrustedSsoController extends Controller
 {
-    public function loginAction(SsoProviderInterface $provider, Request $request, AuthenticationException $exception = null)
+    public function loginAction(ProviderInterface $provider, Request $request, AuthenticationException $exception = null)
     {
         return $this->render(
             'BeSimpleSsoAuthBundle:TrustedSso:login.html.twig',
@@ -16,7 +16,7 @@ class TrustedSsoController extends Controller
         );
     }
 
-    public function logoutAction(SsoProviderInterface $provider, Request $request)
+    public function logoutAction(ProviderInterface $provider, Request $request)
     {
         return $this->render(
             'BeSimpleSsoAuthBundle:TrustedSso:logout.html.twig',

--- a/DependencyInjection/Security/Factory/OpenSsoFactory.php
+++ b/DependencyInjection/Security/Factory/OpenSsoFactory.php
@@ -6,7 +6,7 @@ use Symfony\Component\Config\Definition\Builder\NodeDefinition;
 use Symfony\Component\DependencyInjection\DefinitionDecorator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
-use BeSimple\SsoAuthBundle\Sso\SsoProviderInterface;
+use BeSimple\SsoAuthBundle\Sso\ProviderInterface;
 
 class OpenSsoFactory extends AbstractSsoFactory
 {

--- a/DependencyInjection/Security/Factory/TrustedSsoFactory.php
+++ b/DependencyInjection/Security/Factory/TrustedSsoFactory.php
@@ -6,7 +6,7 @@ use Symfony\Component\Config\Definition\Builder\NodeDefinition;
 use Symfony\Component\DependencyInjection\DefinitionDecorator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
-use BeSimple\SsoAuthBundle\Sso\SsoProviderInterface;
+use BeSimple\SsoAuthBundle\Sso\ProviderInterface;
 
 class TrustedSsoFactory extends AbstractSsoFactory
 {

--- a/Resources/config/sso_providers.xml
+++ b/Resources/config/sso_providers.xml
@@ -5,7 +5,7 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <parameters>
-        <parameter key="be_simple_sso_auth.sso_factory.class">BeSimple\SsoAuthBundle\Sso\SsoFactory</parameter>
+        <parameter key="be_simple_sso_auth.sso_factory.class">BeSimple\SsoAuthBundle\Sso\Factory</parameter>
         <parameter key="be_simple_sso_auth.sso_provider.cas.class">BeSimple\SsoAuthBundle\Sso\Cas\CasProvider</parameter>
         <parameter key="be_simple_sso_auth.sso_server.cas.class">BeSimple\SsoAuthBundle\Sso\Cas\CasServer</parameter>
     </parameters>

--- a/Security/Core/Authentication/Provider/SsoAuthenticationProvider.php
+++ b/Security/Core/Authentication/Provider/SsoAuthenticationProvider.php
@@ -10,9 +10,9 @@ use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Core\Exception\UsernameNotFoundException;
 use Symfony\Component\Security\Core\Exception\AuthenticationServiceException;
 use Symfony\Component\Security\Core\Exception\BadCredentialsException;
-use BeSimple\SsoAuthBundle\Sso\SsoProviderInterface;
+use BeSimple\SsoAuthBundle\Sso\ProviderInterface;
 use BeSimple\SsoAuthBundle\Security\Core\Authentication\Token\SsoToken;
-use BeSimple\SsoAuthBundle\Sso\SsoValidationInterface;
+use BeSimple\SsoAuthBundle\Sso\ValidationInterface;
 
 class SsoAuthenticationProvider implements AuthenticationProviderInterface
 {
@@ -60,7 +60,7 @@ class SsoAuthenticationProvider implements AuthenticationProviderInterface
             return null;
         }
 
-        $ssoProvider = $token->getSsoProvider();
+        $ssoProvider = $token->getProvider();
         $validation  = $this->validateCredentials($ssoProvider, $token->getCredentials());
         $user        = $this->provideUser($ssoProvider, $validation);
 
@@ -87,7 +87,7 @@ class SsoAuthenticationProvider implements AuthenticationProviderInterface
      * @param SsoToken $token
      * @return UserInterface
      */
-    protected function provideUser(SsoProviderInterface $ssoProvider, SsoValidationInterface $validation)
+    protected function provideUser(ProviderInterface $ssoProvider, ValidationInterface $validation)
     {
         $username = $ssoProvider->formatUsername($validation->getUsername());
 
@@ -155,11 +155,11 @@ class SsoAuthenticationProvider implements AuthenticationProviderInterface
 
     /**
      * @throws BadCredentialsException
-     * @param SsoProviderInterface $ssoProvider
+     * @param ProviderInterface $ssoProvider
      * @param string $credentials
      * @return SsoValidationInterface
      */
-    protected function validateCredentials(SsoProviderInterface $ssoProvider, $credentials)
+    protected function validateCredentials(ProviderInterface $ssoProvider, $credentials)
     {
         $validation = $ssoProvider->validateCredentials($credentials);
 

--- a/Security/Http/EntryPoint/TrustedSsoAuthenticationEntryPoint.php
+++ b/Security/Http/EntryPoint/TrustedSsoAuthenticationEntryPoint.php
@@ -7,7 +7,7 @@ use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Bundle\FrameworkBundle\HttpKernel;
-use BeSimple\SsoAuthBundle\Sso\SsoFactory;
+use BeSimple\SsoAuthBundle\Sso\Factory;
 
 class TrustedSsoAuthenticationEntryPoint implements AuthenticationEntryPointInterface
 {
@@ -31,7 +31,7 @@ class TrustedSsoAuthenticationEntryPoint implements AuthenticationEntryPointInte
      * @param SsoProviderFactory $ssoFactory
      * @param array $ssoConfig
      */
-    public function __construct(HttpKernel $httpKernel, SsoFactory $ssoFactory, array $config)
+    public function __construct(HttpKernel $httpKernel, Factory $ssoFactory, array $config)
     {
         $this->httpKernel = $httpKernel;
         $this->ssoFactory = $ssoFactory;

--- a/Security/Http/Firewall/TrustedSsoAuthenticationListener.php
+++ b/Security/Http/Firewall/TrustedSsoAuthenticationListener.php
@@ -13,13 +13,13 @@ use Symfony\Component\Security\Http\Firewall\AbstractAuthenticationListener;
 use Symfony\Component\Security\Http\HttpUtils;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use BeSimple\SsoAuthBundle\Security\Core\Authentication\Provider\SsoAuthenticationProvider;
-use BeSimple\SsoAuthBundle\Sso\SsoFactory;
+use BeSimple\SsoAuthBundle\Sso\Factory;
 
 class TrustedSsoAuthenticationListener extends AbstractAuthenticationListener
 {
     private $ssoFactory;
 
-    public function __construct(SecurityContextInterface $securityContext, AuthenticationManagerInterface $authenticationManager, SessionAuthenticationStrategyInterface $sessionStrategy, HttpUtils $httpUtils, $providerKey, SsoFactory $ssoFactory, array $options = array(), AuthenticationSuccessHandlerInterface $successHandler = null, AuthenticationFailureHandlerInterface $failureHandler = null, LoggerInterface $logger = null, EventDispatcherInterface $dispatcher = null)
+    public function __construct(SecurityContextInterface $securityContext, AuthenticationManagerInterface $authenticationManager, SessionAuthenticationStrategyInterface $sessionStrategy, HttpUtils $httpUtils, $providerKey, Factory $ssoFactory, array $options = array(), AuthenticationSuccessHandlerInterface $successHandler = null, AuthenticationFailureHandlerInterface $failureHandler = null, LoggerInterface $logger = null, EventDispatcherInterface $dispatcher = null)
     {
         parent::__construct($securityContext, $authenticationManager, $sessionStrategy, $httpUtils, $providerKey, $options, $successHandler, $failureHandler, $logger, $dispatcher);
 

--- a/Sso/Cas/CasV1Validation.php
+++ b/Sso/Cas/CasV1Validation.php
@@ -2,11 +2,11 @@
 
 namespace BeSimple\SsoAuthBundle\Sso\Cas;
 
-use BeSimple\SsoAuthBundle\Sso\AbstractSsoValidation;
-use BeSimple\SsoAuthBundle\Sso\SsoValidationInterface;
+use BeSimple\SsoAuthBundle\Sso\AbstractValidation;
+use BeSimple\SsoAuthBundle\Sso\ValidationInterface;
 use Buzz\Message\Response;
  
-class CasV1Validation extends AbstractSsoValidation implements SsoValidationInterface
+class CasV1Validation extends AbstractValidation implements ValidationInterface
 {
     protected function validateResponse(Response $response)
     {

--- a/Tests/Controller/TrustedSsoController.php
+++ b/Tests/Controller/TrustedSsoController.php
@@ -4,14 +4,14 @@ namespace BeSimple\SsoAuthBundle\Tests\Controller;
 
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
-use BeSimple\SsoAuthBundle\Sso\SsoProviderInterface;
+use BeSimple\SsoAuthBundle\Sso\ProviderInterface;
 
 class TrustedSsoController extends Controller
 {
     const LOGIN_REQUIRED_MESSAGE  = 'login required';
     const LOGOUT_REDIRECT_MESSAGE = 'logout redirection';
 
-    public function loginAction(SsoProviderInterface $provider, Request $request, AuthenticationException $exception = null)
+    public function loginAction(ProviderInterface $provider, Request $request, AuthenticationException $exception = null)
     {
         return $this->render('common/link.html.twig', array(
             'message' => self::LOGIN_REQUIRED_MESSAGE,
@@ -19,7 +19,7 @@ class TrustedSsoController extends Controller
         ));
     }
 
-    public function logoutAction(SsoProviderInterface $provider, Request $request)
+    public function logoutAction(ProviderInterface $provider, Request $request)
     {
         return $this->render('common/link.html.twig', array(
             'message' => self::LOGOUT_REDIRECT_MESSAGE,

--- a/Tests/Unit/TestCase.php
+++ b/Tests/Unit/TestCase.php
@@ -2,9 +2,9 @@
 
 namespace BeSimple\SsoAuthBundle\Tests\Unit;
 
-use BeSimple\SsoAuthBundle\Sso\SsoProviderInterface;
-use BeSimple\SsoAuthBundle\Sso\SsoServerInterface;
-use BeSimple\SsoAuthBundle\Sso\SsoValidationInterface;
+use BeSimple\SsoAuthBundle\Sso\ProviderInterface;
+use BeSimple\SsoAuthBundle\Sso\ServerInterface;
+use BeSimple\SsoAuthBundle\Sso\ValidationInterface;
 use Buzz\Message\Response;
 use Buzz\Client\FileGetContents;
 
@@ -20,21 +20,21 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase
 
     abstract public function provideServers();
 
-    protected function createProvider(SsoProviderInterface $provider, $version, $baseUrl, $returnUrl, $usernameFormat)
+    protected function createProvider(ProviderInterface $provider, $version, $baseUrl, $returnUrl, $usernameFormat)
     {
         $this->configureServer($provider->getServer(), $version, $baseUrl, $returnUrl, $usernameFormat);
 
         return $provider;
     }
 
-    protected function createServer(SsoServerInterface $server, $version, $baseUrl, $returnUrl, $usernameFormat)
+    protected function createServer(ServerInterface $server, $version, $baseUrl, $returnUrl, $usernameFormat)
     {
         $this->configureServer($server, $version, $baseUrl, $returnUrl, $usernameFormat);
 
         return $server;
     }
 
-    protected function createValidation(SsoValidationInterface $validation, $content)
+    protected function createValidation(ValidationInterface $validation, $content)
     {
         $response = new Response();
         $response->setContent($content);
@@ -42,7 +42,7 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase
         return $validation->setResponse($response);
     }
 
-    private function configureServer(SsoServerInterface $server, $version, $baseUrl, $returnUrl, $usernameFormat)
+    private function configureServer(ServerInterface $server, $version, $baseUrl, $returnUrl, $usernameFormat)
     {
         $server
             ->setBaseUrl($baseUrl)


### PR DESCRIPTION
Hi Simon,

When installing the bundle I had a lot of errors saying a particular class or method could not be found.
It seemed that all the classes in Sso/ were targeted with the Sso prefix, but this prefix is not included in the class itself.

Hope I can help!

Kind Regards,
Christian Vermeulen
