### PR TITLE
Moved SsoToken::validationAtrribures to attributes['sso:validation']. Ma...

### DIFF
--- a/Security/Core/Authentication/Provider/SsoAuthenticationProvider.php
+++ b/Security/Core/Authentication/Provider/SsoAuthenticationProvider.php
@@ -85,7 +85,12 @@ class SsoAuthenticationProvider implements AuthenticationProviderInterface
         $this->userChecker->checkPostAuth($user);
 
         $authenticatedToken = new SsoToken($token->getManager(), $token->getCredentials(), $user, $user->getRoles(), $validation->getAttributes());
-        $authenticatedToken->setAttributes($token->getAttributes());
+        foreach ($token->getAttributes() as $name => $value) {
+            if ('sso:validation' == $name) {
+                continue;
+            }
+            $authenticatedToken->setAttribute($name, $value);
+        }
 
         return $authenticatedToken;
     }

--- a/Security/Core/Authentication/Token/SsoToken.php
+++ b/Security/Core/Authentication/Token/SsoToken.php
@@ -9,7 +9,6 @@ class SsoToken extends AbstractToken
 {
     private $manager;
     private $credentials;
-    private $validationAttributes;
 
     /**
      * Constructor.
@@ -27,7 +26,8 @@ class SsoToken extends AbstractToken
 
         $this->manager              = $manager;
         $this->credentials          = $credentials;
-        $this->validationAttributes = $validationAttributes;
+
+        $this->setAttribute('sso:validation', $validationAttributes);
 
         if (!is_null($user)) {
             $this->setUser($user);
@@ -60,7 +60,11 @@ class SsoToken extends AbstractToken
 
     public function getValidationAttributes()
     {
-        return $this->validationAttributes;
+        if (!$this->hasAttribute('sso:validation')) {
+            return array();
+        }
+
+        return $this->getAttribute('sso:validation');
     }
 
     /**


### PR DESCRIPTION
...kes it easier to transfer attributes to a new Token and fixes that we never serialized validation attributes.
