### PR TITLE
Add CURLOPT_SSL_VERIFYPEER option for Buzz client

### DIFF
--- a/Buzz/AdaptiveClient.php
+++ b/Buzz/AdaptiveClient.php
@@ -14,14 +14,16 @@ use Buzz\Message\RequestInterface;
 class AdaptiveClient implements ClientInterface
 {
     private $client;
+    private $options;
 
-    public function __construct()
+    public function __construct(array $options = array())
     {
+        $this->options = $options;
         $this->client = function_exists('curl_init') ? new Curl() : new FileGetContents();
     }
 
     public function send(RequestInterface $request, MessageInterface $response)
     {
-        $this->client->send($request, $response);
+        $this->client->send($request, $response, $this->options);
     }
 }

--- a/Resources/config/factory.xml
+++ b/Resources/config/factory.xml
@@ -7,10 +7,15 @@
     <parameters>
         <parameter key="be_simple.sso_auth.factory.class">BeSimple\SsoAuthBundle\Sso\Factory</parameter>
         <parameter key="be_simple.sso_auth.client.class">BeSimple\SsoAuthBundle\Buzz\AdaptiveClient</parameter>
+        <parameter key="be_simple.sso_auth.client.option.curlopt_ssl_verifypeer.key">64</parameter>
+        <parameter key="be_simple.sso_auth.client.option.curlopt_ssl_verifypeer.value">TRUE</parameter>
     </parameters>
 
     <services>
         <service id="be_simple.sso_auth.client" class="%be_simple.sso_auth.client.class%">
+            <argument type="collection">
+                <argument key="%be_simple.sso_auth.client.option.curlopt_ssl_verifypeer.key%">%be_simple.sso_auth.client.option.curlopt_ssl_verifypeer.value%</argument>
+            </argument>
         </service>
 
         <service id="be_simple.sso_auth.factory" class="%be_simple.sso_auth.factory.class%">


### PR DESCRIPTION
The default value of CURLOPT_SSL_VERIFYPEER is set to TRUE, but the purpose of adding the parameter is to make it overridable in app/config/parameters.yml. Having this option available is helpful when working with dev CAS servers that have self-signed certs.
