### PR TITLE
Added ssl version parameter.

### DIFF
--- a/Resources/config/factory.xml
+++ b/Resources/config/factory.xml
@@ -9,12 +9,15 @@
         <parameter key="be_simple.sso_auth.client.class">BeSimple\SsoAuthBundle\Buzz\AdaptiveClient</parameter>
         <parameter key="be_simple.sso_auth.client.option.curlopt_ssl_verifypeer.key">64</parameter>
         <parameter key="be_simple.sso_auth.client.option.curlopt_ssl_verifypeer.value">TRUE</parameter>
+        <parameter key="be_simple.sso_auth.client.option.curlopt_sslversion.key">32</parameter>
+        <parameter key="be_simple.sso_auth.client.option.curlopt_sslversion.value">3</parameter>
     </parameters>
 
     <services>
         <service id="be_simple.sso_auth.client" class="%be_simple.sso_auth.client.class%">
             <argument type="collection">
                 <argument key="%be_simple.sso_auth.client.option.curlopt_ssl_verifypeer.key%">%be_simple.sso_auth.client.option.curlopt_ssl_verifypeer.value%</argument>
+                <argument key="%be_simple.sso_auth.client.option.curlopt_sslversion.key%">%be_simple.sso_auth.client.option.curlopt_sslversion.value%</argument>
             </argument>
         </service>
 

--- a/Resources/doc/example.md
+++ b/Resources/doc/example.md
@@ -76,3 +76,12 @@ This is handy when using a development server that does not have a valid certifi
 
     # app/config/parameters.yml
     be_simple.sso_auth.client.option.curlopt_ssl_verifypeer.value: FALSE
+    
+If necessary, you can change curl sslversion.
+----------------------------------------------------------
+
+This is really necesary because in some cases this must be set manually or when the CAS server is refusing the connection. 
+Default is version 3.
+
+    # app/config/parameters.yml
+    be_simple.sso_auth.client.option.curlopt_sslversion.value: 3


### PR DESCRIPTION
In some cases is need to be set the curl ssl version parameter because  some CAS servers are refusing the default PHP configuration. 

I don't  recommend anyone let PHP dynamically choose the version. - Why? - The reference indicates that in some cases must be provided manually.

Ref.
http://php.net/manual/en/function.curl-setopt.php
