### PR TITLE
Enable retrieving sub-attributes from 'cas:attributes' in cas server response.

### DIFF
--- a/Sso/Cas/XmlValidation.php
+++ b/Sso/Cas/XmlValidation.php
@@ -43,18 +43,16 @@ class XmlValidation extends AbstractValidation implements ValidationInterface
 
                         case 'cas:attributes':
                             foreach($child->childNodes as $attr) {
-                                if ($attr->nodeName != '#text') {
+                                if ($attr->nodeName == 'cas:attribute') {
+                                    $this->getCasAttributes($attr);
+                                } else if ($attr->nodeName != '#text') {
                                     $this->attributes[$attr->nodeName] = $attr->textContent;
                                 }
                             }
                             break;
 
                         case 'cas:attribute':
-                            $name = $child->attributes->getNamedItem('name')->value;
-                            $value = $child->attributes->getNamedItem('value')->value;
-                            if ($name && $value) {
-                                $this->attributes[$name] = $value;
-                            }
+                            $this->getCasAttributes($child);
                             break;
 
                         case '#text':
@@ -74,5 +72,17 @@ class XmlValidation extends AbstractValidation implements ValidationInterface
         }
 
         return $success;
+    }
+
+    /**
+     * @param \DOMElement $node
+     */
+    protected function getCasAttributes(\DOMElement $node)
+    {
+        $name = $node->attributes->getNamedItem('name')->value;
+        $value = $node->attributes->getNamedItem('value')->value;
+        if ($name && $value) {
+            $this->attributes[$name] = $value;
+        }
     }
 }


### PR DESCRIPTION
For instance, with this server response :

``` xml
<cas:serviceResponse xmlns:cas='http://www.example.com/cas'>
    <cas:authenticationSuccess>
        <cas:uid>12345678</cas:uid>
        <cas:user>ext-cturpin</cas:user>
        <cas:attributes>
            <cas:attribute name="mail" value="chturpin@example.com"/>
            <cas:attribute name="displayName" value="ext-Charles-Henri Turpin"/> 
        </cas:attributes>
    </cas:authenticationSuccess>
</cas:serviceResponse>
```

The attributes array will now contains `mail` and `displayName` keys.
