### PR TITLE
fix null manager after unserialization

### DIFF
--- a/Security/Core/Authentication/Token/SsoToken.php
+++ b/Security/Core/Authentication/Token/SsoToken.php
@@ -85,7 +85,7 @@ class SsoToken extends AbstractToken
 
     public function unserialize($str)
     {
-        list($this->credentials, $this->provider, $parentStr) = unserialize($str);
+        list($this->credentials, $this->manager, $parentStr) = unserialize($str);
         parent::unserialize($parentStr);
     }
 }


### PR DESCRIPTION
In SsoToken, the manager was not set after unserialization.