### PR TITLE
expose cURL option for SSL host verification

### DIFF
--- a/Resources/config/factory.xml
+++ b/Resources/config/factory.xml
@@ -13,6 +13,8 @@
         <parameter key="be_simple.sso_auth.client.option.curlopt_sslversion.value">3</parameter>
         <parameter key="be_simple.sso_auth.client.option.curlopt_proxy.key">10004</parameter>
         <parameter key="be_simple.sso_auth.client.option.curlopt_proxy.value"></parameter>
+        <parameter key="be_simple.sso_auth.client.option.curlopt_ssl_verifyhost.key">81</parameter>
+        <parameter key="be_simple.sso_auth.client.option.curlopt_ssl_verifyhost.value">2</parameter>
     </parameters>
 
     <services>
@@ -21,6 +23,7 @@
                 <argument key="%be_simple.sso_auth.client.option.curlopt_ssl_verifypeer.key%">%be_simple.sso_auth.client.option.curlopt_ssl_verifypeer.value%</argument>
 				<argument key="%be_simple.sso_auth.client.option.curlopt_sslversion.key%">%be_simple.sso_auth.client.option.curlopt_sslversion.value%</argument>
                 <argument key="%be_simple.sso_auth.client.option.curlopt_proxy.key%">%be_simple.sso_auth.client.option.curlopt_proxy.value%</argument>
+                <argument key="%be_simple.sso_auth.client.option.curlopt_ssl_verifyhost.key%">%be_simple.sso_auth.client.option.curlopt_ssl_verifyhost.value%</argument>
             </argument>
         </service>
 

--- a/Resources/doc/example.md
+++ b/Resources/doc/example.md
@@ -69,10 +69,11 @@ When a user successfully authenticates, but is not in the user provider's data s
 then a generic error page is shown indicating that the user was not found. You can customize this error page by overriding the Twig error template,
 as described here: http://symfony.com/doc/current/cookbook/controller/error_pages.html
 
-If necessary, you can disable SSL Certificate Verification
-----------------------------------------------------------
+If necessary, you can disable SSL Certificate and/or Host Verification
+----------------------------------------------------------------------
 
 This is handy when using a development server that does not have a valid certificate, but it should not be done in production.
 
     # app/config/parameters.yml
     be_simple.sso_auth.client.option.curlopt_ssl_verifypeer.value: FALSE
+    be_simple.sso_auth.client.option.curlopt_ssl_verifyhost.value: 0


### PR DESCRIPTION
It can be very useful to be able to disable the SSL host verification while in development phase.
