### PR TITLE
Update for Symfony 3

### DIFF
--- a/Controller/Controller.php
+++ b/Controller/Controller.php
@@ -2,11 +2,26 @@
 
 namespace BeSimple\SsoAuthBundle\Controller;
 
-use Symfony\Component\DependencyInjection\ContainerAware;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
-class Controller extends ContainerAware
+class Controller implements ContainerAwareInterface
 {
+    /**
+     * @var ContainerInterface $container
+     */
+    private $container;
+
+    /**
+     * Sets the container.
+     *
+     * @param ContainerInterface|null $container A ContainerInterface instance or null
+     */
+    public function setContainer(ContainerInterface $container = null)
+    {
+        $this->container=$container;
+    }
+
     protected function render($view, array $parameters)
     {
         return $this


### PR DESCRIPTION
ContainerAware was removed in Symfony 3.x.