### PR TITLE
Fix compatibility with kriswallsmith/buzz

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=5.3.3",
-        "kriswallsmith/buzz": ">=0.7,<1.0-dev",
+        "kriswallsmith/buzz": ">=0.7,<=0.16.1",
         "symfony/framework-bundle": "~2.1|~3.0",
         "symfony/twig-bundle": "~2.1|~3.0",
         "symfony/security-bundle": "~2.1|~3.0"


### PR DESCRIPTION
There is an incompatibility since the 0.17.0 version of kriswallsmith/buzz. The last compatibility version is the 0.16.1.